### PR TITLE
allow newlines or whitespace in base64 during parsing

### DIFF
--- a/lib/fb2rb.rb
+++ b/lib/fb2rb.rb
@@ -712,7 +712,7 @@ module FB2rb
     end
 
     def self.parse(xml)
-      decoded = xml.text.unpack1('m0')
+      decoded = xml.text.unpack1('m')
       Binary.new(id: xml['id'], content: decoded, content_type: xml['content-type'])
     end
 


### PR DESCRIPTION
I tried to parse the book from Lev Tolstoy's website: https://tolstoy.ru/creativity/fiction/1071/
and it was throwing
```none
in `unpack': invalid base64 (ArgumentError)
```
because it's encoded with newlines, like this:
```
/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEB
AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wgALCAK6AbwBAREA/8QAHgAB
AAEEAwEBAAAAAAAAAAAAAAgEBQcJAwYKAgH/2gAIAQEAAAABvef7p+X2ks1fdF66hS3OrvFn
que2WLs1It90+OXqtdTWuosfDkGz3f8AL11mq4+Lj4Ki21VrW2yWjsf32/Pne/v7o6p80luv
...
```
I don't know the FB2 specification, but this edit resolves the issue.